### PR TITLE
Fix Github and GoDocs Markdown

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -15,8 +15,8 @@
 // logic required to comply with the specifications and ensure a compliant feed.
 // A number of overrides occur to help with iTunes visibility of your episodes.
 //
-// Notably, the [Podcast.AddItem(i Item)](#Podcast.AddItem) function performs most
-// of the heavy lifting by taking the [Item](#Item) input and performing
+// Notably, the `Podcast.AddItem` function performs most
+// of the heavy lifting by taking the `Item` input and performing
 // validation, overrides and duplicate setters through the feed.
 //
 // Full detailed Examples of the API are at https://godoc.org/github.com/eduncan911/podcast.
@@ -50,33 +50,33 @@
 // Release Notes
 //
 // 1.3.1
-// * increased itunes compliance after feedback from Apple:
-// - specified what categories should be set with AddCategory().
-// - enforced title and link as part of Image.
-// * added Podcast.AddAtomLink() for more broad compliance to readers.
+//   * increased itunes compliance after feedback from Apple:
+//     - specified what categories should be set with AddCategory().
+//     - enforced title and link as part of Image.
+//   * added Podcast.AddAtomLink() for more broad compliance to readers.
 //
 // 1.3.0
-// * fixes Item.Duration being set incorrectly.
-// * changed Item.AddEnclosure() parameter definition (Bytes not Seconds!).
-// * added Item.AddDuration formatting and override.
-// * added more documentation surrounding Item.Enclosure{}
+//   * fixes Item.Duration being set incorrectly.
+//   * changed Item.AddEnclosure() parameter definition (Bytes not Seconds!).
+//   * added Item.AddDuration formatting and override.
+//   * added more documentation surrounding Item.Enclosure{}
 //
 // 1.2.1
-// * added Podcast.AddSubTitle() and truncating to 64 chars.
-// * added a number of Guards to protect against empty fields.
+//   * added Podcast.AddSubTitle() and truncating to 64 chars.
+//   * added a number of Guards to protect against empty fields.
 //
 // 1.2.0
-// * added Podcast.AddPubDate() and Podcast.AddLastBuildDate() overrides.
-// * added Item.AddImage() to mask some cumbersome addition of IImage.
-// * added Item.AddPubDate to simply datetime setters.
-// * added more examples (mostly around Item struct).
-// * tweaked some documentation.
+//   * added Podcast.AddPubDate() and Podcast.AddLastBuildDate() overrides.
+//   * added Item.AddImage() to mask some cumbersome addition of IImage.
+//   * added Item.AddPubDate to simply datetime setters.
+//   * added more examples (mostly around Item struct).
+//   * tweaked some documentation.
 //
 // 1.1.0
-// * Enabling CDATA in ISummary fields for Podcast and Channel.
+//   * Enabling CDATA in ISummary fields for Podcast and Channel.
 //
 // 1.0.0
-// * Initial release.
-// * Full documentation, full examples and complete code coverage.
+//   * Initial release.
+//   * Full documentation, full examples and complete code coverage.
 //
 package podcast

--- a/item.go
+++ b/item.go
@@ -87,7 +87,7 @@ func (i *Item) AddPubDate(datetime *time.Time) {
 // Limit: 4000 characters
 //
 // Note that this field is a CDATA encoded field which allows for rich text
-// such as html links: <a href="http://www.apple.com">Apple</a>.
+// such as html links: `<a href="http://www.apple.com">Apple</a>`.
 func (i *Item) AddSummary(summary string) {
 	count := utf8.RuneCountInString(summary)
 	if count > 4000 {

--- a/itunes.go
+++ b/itunes.go
@@ -27,7 +27,7 @@ type IImage struct {
 
 // ISummary is a 4000 character rich-text field for the itunes:summary tag.
 //
-// This is rendered as CDATA which allows for HTML tags such as <a href="">.
+// This is rendered as CDATA which allows for HTML tags such as `<a href="">`.
 type ISummary struct {
 	XMLName xml.Name `xml:"itunes:summary"`
 	Text    string   `xml:",cdata"`

--- a/podcast.go
+++ b/podcast.go
@@ -113,73 +113,73 @@ func (p *Podcast) AddAtomLink(href string) {
 // used and will invalidate the feed if deviated from the list.  That list is
 // as follows.
 //
-// Arts
-// * Design
-// * Fashion & Beauty
-// * Food
-// * Literature
-// * Performing Arts
-// * Visual Arts
-// Business
-// * Business News
-// * Careers
-// * Investing
-// * Management & Marketing
-// * Shopping
-// Comedy
-// Education
-// * Education Technology
-// * Higher Education
-// * K-12
-// * Language Courses
-// * Training
-// Games & Hobbies
-// * Automotive
-// * Aviation
-// * Hobbies
-// * Other Games
-// * Video Games
-// Government & Organizations
-// * Local
-// * National
-// * Non-Profit
-// * Regional
-// Health
-// * Alternative Health
-// * Fitness & Nutrition
-// * Self-Help
-// * Sexuality
-// Kids & Family
-// Music
-// News & Politics
-// Religion & Spirituality
-// * Buddhism
-// * Christianity
-// * Hinduism
-// * Islam
-// * Judaism
-// * Other
-// * Spirituality
-// Science & Medicine
-// * Medicine
-// * Natural Sciences
-// * Social Sciences
-// Society & Culture
-// * History
-// * Personal Journals
-// * Philosophy
-// * Places & Travel
-// Sports & Recreation
-// * Amateur
-// * College & High School
-// * Outdoor
-// * Professional
-// Technology
-// * Gadgets
-// * Podcasting
-// * Software How-To
-// * Tech News
-// TV & Film
+// * Arts
+//   * Design
+//   * Fashion & Beauty
+//   * Food
+//   * Literature
+//   * Performing Arts
+//   * Visual Arts
+// * Business
+//   * Business News
+//   * Careers
+//   * Investing
+//   * Management & Marketing
+//   * Shopping
+// * Comedy
+// * Education
+//   * Education Technology
+//   * Higher Education
+//   * K-12
+//   * Language Courses
+//   * Training
+// * Games & Hobbies
+//   * Automotive
+//   * Aviation
+//   * Hobbies
+//   * Other Games
+//   * Video Games
+// * Government & Organizations
+//   * Local
+//   * National
+//   * Non-Profit
+//   * Regional
+// * Health
+//   * Alternative Health
+//   * Fitness & Nutrition
+//   * Self-Help
+//   * Sexuality
+// * Kids & Family
+// * Music
+// * News & Politics
+// * Religion & Spirituality
+//   * Buddhism
+//   * Christianity
+//   * Hinduism
+//   * Islam
+//   * Judaism
+//   * Other
+//   * Spirituality
+// * Science & Medicine
+//   * Medicine
+//   * Natural Sciences
+//   * Social Sciences
+// * Society & Culture
+//   * History
+//   * Personal Journals
+//   * Philosophy
+//   * Places & Travel
+// * Sports & Recreation
+//   * Amateur
+//   * College & High School
+//   * Outdoor
+//   * Professional
+// * Technology
+//   * Gadgets
+//   * Podcasting
+//   * Software How-To
+//   * Tech News
+// * TV & Film
 func (p *Podcast) AddCategory(category string, subCategories []string) {
 	if len(category) == 0 {
 		return
@@ -364,7 +364,7 @@ func (p *Podcast) AddSubTitle(subTitle string) {
 // Limit: 4000 characters
 //
 // Note that this field is a CDATA encoded field which allows for rich text
-// such as html links: <a href="http://www.apple.com">Apple</a>.
+// such as html links: `<a href="http://www.apple.com">Apple</a>`.
 func (p *Podcast) AddSummary(summary string) {
 	count := utf8.RuneCountInString(summary)
 	if count == 0 {

--- a/podcast.go
+++ b/podcast.go
@@ -113,73 +113,73 @@ func (p *Podcast) AddAtomLink(href string) {
 // used and will invalidate the feed if deviated from the list.  That list is
 // as follows.
 //
-// * Arts
-//   * Design
-//   * Fashion & Beauty
-//   * Food
-//   * Literature
-//   * Performing Arts
-//   * Visual Arts
-// * Business
-//   * Business News
-//   * Careers
-//   * Investing
-//   * Management & Marketing
-//   * Shopping
-// * Comedy
-// * Education
-//   * Education Technology
-//   * Higher Education
-//   * K-12
-//   * Language Courses
-//   * Training
-// * Games & Hobbies
-//   * Automotive
-//   * Aviation
-//   * Hobbies
-//   * Other Games
-//   * Video Games
-// * Government & Organizations
-//   * Local
-//   * National
-//   * Non-Profit
-//   * Regional
-// * Health
-//   * Alternative Health
-//   * Fitness & Nutrition
-//   * Self-Help
-//   * Sexuality
-// * Kids & Family
-// * Music
-// * News & Politics
-// * Religion & Spirituality
-//   * Buddhism
-//   * Christianity
-//   * Hinduism
-//   * Islam
-//   * Judaism
-//   * Other
-//   * Spirituality
-// * Science & Medicine
-//   * Medicine
-//   * Natural Sciences
-//   * Social Sciences
-// * Society & Culture
-//   * History
-//   * Personal Journals
-//   * Philosophy
-//   * Places & Travel
-// * Sports & Recreation
-//   * Amateur
-//   * College & High School
-//   * Outdoor
-//   * Professional
-// * Technology
-//   * Gadgets
-//   * Podcasting
-//   * Software How-To
-//   * Tech News
-// * TV & Film
+//   * Arts
+//     * Design
+//     * Fashion & Beauty
+//     * Food
+//     * Literature
+//     * Performing Arts
+//     * Visual Arts
+//   * Business
+//     * Business News
+//     * Careers
+//     * Investing
+//     * Management & Marketing
+//     * Shopping
+//   * Comedy
+//   * Education
+//     * Education Technology
+//     * Higher Education
+//     * K-12
+//     * Language Courses
+//     * Training
+//   * Games & Hobbies
+//     * Automotive
+//     * Aviation
+//     * Hobbies
+//     * Other Games
+//     * Video Games
+//   * Government & Organizations
+//     * Local
+//     * National
+//     * Non-Profit
+//     * Regional
+//   * Health
+//     * Alternative Health
+//     * Fitness & Nutrition
+//     * Self-Help
+//     * Sexuality
+//   * Kids & Family
+//   * Music
+//   * News & Politics
+//   * Religion & Spirituality
+//     * Buddhism
+//     * Christianity
+//     * Hinduism
+//     * Islam
+//     * Judaism
+//     * Other
+//     * Spirituality
+//   * Science & Medicine
+//     * Medicine
+//     * Natural Sciences
+//     * Social Sciences
+//   * Society & Culture
+//     * History
+//     * Personal Journals
+//     * Philosophy
+//     * Places & Travel
+//   * Sports & Recreation
+//     * Amateur
+//     * College & High School
+//     * Outdoor
+//     * Professional
+//   * Technology
+//     * Gadgets
+//     * Podcasting
+//     * Software How-To
+//     * Tech News
+//   * TV & Film
 func (p *Podcast) AddCategory(category string, subCategories []string) {
 	if len(category) == 0 {
 		return
@@ -229,7 +229,7 @@ func (p *Podcast) AddImage(url string) {
 // This method takes the "itunes overrides" approach to populating
 // itunes tags according to the overrides rules in the specification.
 // This not only complies completely with iTunes parsing rules; but, it also
-// displays what is possible to be set on an individual episode level - if you
+// displays what is possible to be set on an individual episode level – if you
 // wish to have more fine grain control over your content.
 //
 // This method imposes strict validation of the Item being added to confirm
@@ -237,32 +237,32 @@ func (p *Podcast) AddImage(url string) {
 //
 // Article minimal requirements are:
 //
-// * Title
-// * Description
-// * Link
+//   * Title
+//   * Description
+//   * Link
 //
 // Audio, Video and Downloads minimal requirements are:
 //
-// * Title
-// * Description
-// * Enclosure (HREF, Type and Length all required)
+//   * Title
+//   * Description
+//   * Enclosure (HREF, Type and Length all required)
 //
 // The following fields are always overwritten (don't set them):
 //
-// * GUID
-// * PubDateFormatted
-// * AuthorFormatted
-// * Enclosure.TypeFormatted
-// * Enclosure.LengthFormatted
+//   * GUID
+//   * PubDateFormatted
+//   * AuthorFormatted
+//   * Enclosure.TypeFormatted
+//   * Enclosure.LengthFormatted
 //
 // Recommendations:
 //
-// * Just set the minimal fields: the rest get set for you.
-// * Always set an Enclosure.Length, to be nice to your downloaders.
-// * Follow Apple's best practices to enrich your podcasts:
-//   https://help.apple.com/itc/podcasts_connect/#/itc2b3780e76
-// * For specifications of itunes tags, see:
-//   https://help.apple.com/itc/podcasts_connect/#/itcb54353390
+//   * Just set the minimal fields: the rest get set for you.
+//   * Always set an Enclosure.Length, to be nice to your downloaders.
+//   * Follow Apple's best practices to enrich your podcasts:
+//     https://help.apple.com/itc/podcasts_connect/#/itc2b3780e76
+//   * For specifications of itunes tags, see:
+//     https://help.apple.com/itc/podcasts_connect/#/itcb54353390
 //
 func (p *Podcast) AddItem(i Item) (int, error) {
 	// initial guards for required fields


### PR DESCRIPTION
This PR fixes some issues in documentation that lead to a bad Markdown rendering in a README.md:
- wrapped few HTML links into inline code blocks
- fixed categories/subcategories list

REAMDE.md itself wasn't updated: relying on`godoc2ghmd`, but let me know if I need to update it.